### PR TITLE
Add match rate calculation for search queries

### DIFF
--- a/src/function/chrome/history.ts
+++ b/src/function/chrome/history.ts
@@ -1,6 +1,8 @@
 import { History, QueryHistoryMessage } from "@/types/chrome";
 import { ResultType } from "@/types/result";
 
+import { calcMatchRateResult } from "@/utils/match";
+
 type InputQueryHistory = Omit<QueryHistoryMessage, "type">;
 
 const defaultEndTime = new Date().getTime();
@@ -26,6 +28,7 @@ const queryHistory = async ({
     id: createRandomId(),
     title: item.title,
     url: item.url,
+    match: calcMatchRateResult(query, item.title, item.url),
   }));
 
   return history as History[];

--- a/src/function/chrome/tab.ts
+++ b/src/function/chrome/tab.ts
@@ -7,6 +7,7 @@ import {
   RemoveMessage,
 } from "@/types/chrome";
 import { ResultType } from "@/types/result";
+import { calcMatchRateResult } from "@/utils/match";
 
 const queryTabs = async (query: string, option: QueryOption) => {
   const response = await actionQuery(query, {
@@ -24,6 +25,7 @@ const queryTabs = async (query: string, option: QueryOption) => {
         active: tab.active || false,
         lastAccessed: tab.lastAccessed || 0,
         windowId: tab.windowId || 0,
+        match: calcMatchRateResult(query, tab.title, tab.url),
       } as Tab;
     })
     .sort((a, b) => b.lastAccessed - a.lastAccessed);

--- a/src/function/google/query.ts
+++ b/src/function/google/query.ts
@@ -1,6 +1,8 @@
 import { Suggestion, SuggestionOptions } from "@/types/google";
 import { ResultType } from "@/types/result";
 
+import { calcMatchRateResult } from "@/utils/match";
+
 const suggest_url = "https://suggestqueries.google.com/complete/search";
 const search_url = "https://www.google.com/search";
 
@@ -29,6 +31,7 @@ export const querySuggestions = async (
         title,
         url,
         type: ResultType.Google,
+        match: calcMatchRateResult(query, title, url),
       } as Suggestion;
     });
   } catch (error) {

--- a/src/hooks/query/useQueryHistories.ts
+++ b/src/hooks/query/useQueryHistories.ts
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 import { History, MessageType } from "@/types/chrome";
 import { ResultType } from "@/types/result";
 
-const DEFAULT_COUNT = undefined;
 const DEFAULT_TAB_COUNT = 3;
 
 export default function useQueryHistories(
@@ -11,7 +10,6 @@ export default function useQueryHistories(
   tabCount: number
 ) {
   const [history, setHistory] = useState<History[]>([]);
-  const [count, setCount] = useState<number | undefined>(DEFAULT_COUNT);
 
   useEffect(() => {
     if (type !== ResultType.History && type !== ResultType.All) {

--- a/src/hooks/query/useQueryResult.ts
+++ b/src/hooks/query/useQueryResult.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
+
 import useQueryTabs from "@/hooks/query/useQueryTabs";
 import useQuerySuggestions from "@/hooks/query/useQuerySuggestions";
-import useQueryHistories from "./useQueryHistories";
+import useQueryHistories from "@/hooks/query/useQueryHistories";
 
 import { ResultType, Result } from "@/types/result";
 
@@ -11,20 +12,13 @@ export default function useResult(query: string, type: ResultType) {
   const { suggestions } = useQuerySuggestions(query, type, tabs.length);
   const { histories } = useQueryHistories(query, type, tabs.length);
 
-  const sortResult = (a: Result, b: Result) => {
-    if (a.title.includes(query) && !b.title.includes(query)) {
-      return -1;
-    }
-    if (!a.title.includes(query) && b.title.includes(query)) {
-      return 1;
-    }
-    return 0;
-  };
-
   useEffect(() => {
-    const result = [...tabs, ...suggestions, ...histories].sort(sortResult);
-    setResult(result);
-  }, [tabs, suggestions, histories]);
+    const items = [...tabs, ...suggestions, ...histories].sort(
+      (a, b) => b.match - a.match
+    );
+
+    setResult(items);
+  }, [query, tabs, suggestions, histories]);
 
   return {
     result,

--- a/src/types/chrome.ts
+++ b/src/types/chrome.ts
@@ -25,6 +25,7 @@ export interface Tab {
   lastAccessed: number;
   windowId: number;
   currentWindow: boolean;
+  match: number;
 }
 
 export type QueryOption = Pick<chrome.tabs.QueryInfo, "currentWindow"> & {
@@ -58,6 +59,7 @@ export interface History {
   id: number;
   title: string;
   url: string;
+  match: number;
 }
 
 export interface QueryHistoryMessage {

--- a/src/types/google.ts
+++ b/src/types/google.ts
@@ -9,4 +9,5 @@ export interface Suggestion {
   type: ResultType.Google;
   title: string;
   url: string;
+  match: number;
 }

--- a/src/utils/algorithm.ts
+++ b/src/utils/algorithm.ts
@@ -20,4 +20,4 @@ function getNgrams(str: string, n: number): string[] {
   return ngrams;
 }
 
-export { ngramSimilarity };
+export { ngramSimilarity, getNgrams };

--- a/src/utils/match.ts
+++ b/src/utils/match.ts
@@ -1,0 +1,22 @@
+import { getNgrams } from "@/utils/algorithm";
+
+const calculateMatchRate = (query: string, target: string): number => {
+  const ngrams1 = getNgrams(query, 2);
+  const ngrams2 = getNgrams(target, 2);
+  // 下の処理の説明をして
+  const intersection = ngrams1.filter((ngram) => ngrams2.includes(ngram));
+
+  return intersection.length / ngrams1.length;
+};
+
+const calcMatchRateResult = (
+  query: string,
+  title?: string,
+  url?: string
+): number => {
+  const titleMatch = title ? calculateMatchRate(query, title) : 0;
+  const urlMatch = url ? calculateMatchRate(query, url) : 0;
+  return titleMatch > urlMatch ? titleMatch : urlMatch;
+};
+
+export { calcMatchRateResult };


### PR DESCRIPTION
Introduce functionality to calculate match rates based on search queries and include these rates in the results for history, tabs, and suggestions. This enhancement improves the relevance of displayed results.